### PR TITLE
Remove SMS link

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,6 +5,9 @@ class CatalogController < ApplicationController
 
   include Blacklight::Catalog
 
+  def sms_mappings
+  end
+
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {


### PR DESCRIPTION
This only sort of works and the GIS team decided they didn't need/want
it. Redefining the sms_mappings method seemed like the easiest way to do
this.