### PR TITLE
Fix search box

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<% if has_search_parameters? %>
+<% if controller_name == 'catalog' && has_search_parameters? %>
   <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="<%= container_classes %>">
       <%= render_search_bar  %>


### PR DESCRIPTION
An earlier change to remove the search box in the navbar on the front
page also broke the history and saved searches pages. This should fix
those.