### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+tmp
+log
+.git
+.env
+db/*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.4
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+
+WORKDIR /geoweb
+COPY Gemfile* /geoweb/
+RUN bundle install --deployment --without development test
+
+COPY . /geoweb/
+
+EXPOSE 3000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.4"
+services:
+  web:
+    image: geoweb
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: 1
+      RAILS_SERVE_STATIC_FILES: 1
+      POSTGRES_DATABASE: postgres
+      POSTGRES_HOST: db
+      POSTGRES_USERNAME: postgres
+      SECRET_KEY_BASE:
+      SOLR_URL: http://solr:8983/solr/geoweb
+  db:
+    image: postgres
+  solr:
+    image: solr
+    command: solr-create -c geoweb -d /solr/conf
+    volumes:
+      - ./solr/conf:/solr/conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+bundle exec rake db:setup || bundle exec rake db:migrate
+bundle exec rake assets:precompile
+bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
This adds a Dockerfile and docker-compose.yml file. You'll need to have
SECRET_KEY_BASE set in your env to use docker-compose. It will start up
a postgres db and solr instance with a geoblacklight core configured.
There's no data loaded, yet.