### PR TITLE
Move asset compilation to image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ COPY Gemfile* /geoweb/
 RUN bundle install --deployment --without development test
 
 COPY . /geoweb/
+# Devise needs a secret key set, but what the key is doesn't matter when
+# compiling assets. Use a different secret key when running in production.
+RUN \
+  SECRET_KEY_BASE=986ba3e063377eee3e36b656ae97c82dfb4d24f835fc98b8dc83a206c41090a10d1b496e40c29cf1506fc6bb38b6475cf01677fa45e9157b4e7c65dd7ce3aeeb \
+  RAILS_ENV=production \
+  bundle exec rake assets:precompile
 
 EXPOSE 3000
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,4 @@
 set -e
 
 bundle exec rake db:setup || bundle exec rake db:migrate
-bundle exec rake assets:precompile
 bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
The secret key doesn't matter when compiling the assets so we can just
set whatever and compile the assets during the build process. Container
startup is much faster this way.