### PR TITLE
Remove lingering pid file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,7 @@
 set -e
 
 bundle exec rake db:setup || bundle exec rake db:migrate
+# This seems to be necessary when reusing the same image, e.g. during
+# docker restart
+rm -f tmp/pids/server.pid
 bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
The usual container shutdown does not seem to consistently remove the
Rails pid. This can cause the next restart to fail if reusing the same
container, as happens with multiple docker-compose up commands.