### PR TITLE
Replace jumbotron search box

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,15 +1,3 @@
-<div class='jumbotron'>
-  <div class='home-search-area'>
-    <%= content_tag :h2, t('geoblacklight.home.headline') %>
-    <%= content_tag :h3, t('geoblacklight.home.search_heading') %>
-    <div class='row'>
-      <div class='col-md-6 col-md-offset-3'>
-        <%= render_search_form_no_navbar %>
-      </div>
-    </div>
-  </div>
-</div>
-
 <div class='container'>
   <div class='row'>
     <h2>Explore</h2>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<% if controller_name == 'catalog' && has_search_parameters? %>
+<% if controller_name == 'catalog' %>
   <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="<%= container_classes %>">
       <%= render_search_bar  %>


### PR DESCRIPTION
This replaces the jumbotron search box on the front page with the
regular search box that appears elsewhere. It was decided that this
provides a more consistent experience.