### PR TITLE
Add modal partial to layout

### DIFF
--- a/app/views/layouts/geoweb.html.erb
+++ b/app/views/layouts/geoweb.html.erb
@@ -39,5 +39,6 @@
   </div>
 
   <%= render partial: 'shared/footer' %>
+  <%= render partial: 'shared/ajax_modal' %>
   </body>
 </html>


### PR DESCRIPTION
This fixes a regression from adding the new geoweb layout. Modals had no
div to attach to so they did not appear.