### PR TITLE
Remove saved searches

### DIFF
--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -1,0 +1,18 @@
+<% @page_title = t('blacklight.search_history.page_title', :application_name => application_name) %>
+
+<div id="content" class="col-md-12">
+<h2 class='page-heading'><%=t('blacklight.search_history.title')%></h2>
+<%- if @searches.blank? -%>
+  <h3 class='section-heading'><%=t('blacklight.search_history.no_history')%></h3>
+<%- else -%>
+  <%= link_to t('blacklight.search_history.clear.action_title'), blacklight.clear_search_history_path, :method => :delete, :data => { :confirm => t('blacklight.search_history.clear.action_confirm') }, :class => 'btn btn-danger float-md-right' %>
+  <h3 class='section-heading'><%=t('blacklight.search_history.recent')%></h3>
+  <table class="table table-striped search-history">
+    <%-  @searches.each_with_index do |search,index| -%>
+    <%= content_tag :tr, :id => "document_#{index + 1}" do %>
+      <td class="query"><%= link_to_previous_search(search_state.reset(search.query_params).to_hash) %></td>
+    <% end #content_tag %>
+  <%- end -%>
+  </table>
+<%- end -%>
+</div>


### PR DESCRIPTION
This has already been removed in recent versions of blacklight, but
geoblacklight has not upgraded its blacklight version yet. We don't want
this feature, so I'm just removing it from the UI. The routes and logic
are still there, but will eventually get removed.