### PR TITLE
Add source setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ FIELDS:
   :PART_OF: 'dct_isPartOf_sm'
   :TEMPORAL: 'dct_temporal_sm'
   :TITLE: 'dc_title_s'
+  :SOURCE: 'dc_source_sm'
 
 # Institution deployed at
 INSTITUTION: 'MIT'


### PR DESCRIPTION
Apparently a change in geoblacklight was made a while ago that requires
a new setting.