### PR TITLE
Downgrade blacklight to 6.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'blacklight', '~> 6.14.0'
 gem 'bootsnap'
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       execjs
     bcrypt (3.1.12)
     bindex (0.5.0)
-    blacklight (6.16.0)
+    blacklight (6.14.1)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
@@ -334,6 +334,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  blacklight (~> 6.14.0)
   bootsnap
   byebug
   coffee-rails (~> 4.2)


### PR DESCRIPTION
The upgrade to 6.16 resulted in deprecation warnings flooding the logs.
I can't figure out how to turn off the deprecation warnings. The problem
is ultimately in geoblacklight using deprecated blacklight behavior. The
solution is to upgrade geoblacklight, but that will take some time since
the newest version introduced some significant changes.