### PR TITLE
Direct S3 Downloads of layer zip files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.6.1'
 
+gem 'aws-sdk-s3'
 gem 'blacklight', '~> 6.14.0'
 gem 'bootsnap'
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,22 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.4.10.2)
       execjs
+    aws-eventstream (1.0.3)
+    aws-partitions (1.189.0)
+    aws-sdk-core (3.59.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.23.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.45.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
     bindex (0.5.0)
     blacklight (6.14.1)
@@ -167,6 +183,7 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -334,6 +351,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   blacklight (~> 6.14.0)
   bootsnap
   byebug
@@ -364,4 +382,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ This is the codebase for MIT's GeoBlacklight instance.
 
 See https://github.mit.edu/mitlibraries/geodeploy for instructions on how to deploy this.
 
+# Shapefile downloads
+
+We are using pre-signed download URLs to directly provide links to S3 for
+public layers or if the user is authenticated.
+
+The following ENV are required for this functionality:
+
+- AWS_REGION
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- AWS_S3_BUCKET
+
+In development / test it is assumed Minio is in use and you must also set:
+
+- MINIO_URL. `http://localhost:9000` is likely what you want
+
+The download link is set in the metadata for the objects, so in development / test / staging environments this will very likely send you to a production instance when you click the Download links in-app. If you copy the URL and manually change the server to the domain appropriate to your environment you should be able to see the downloads work. Alternately, you can load metadata that has been constructed to have appropriate URLs for your environment.
+
 # Local development
 
 The `docker-compose.yml` file can be used to start up a full GeoWeb stack for local development. There are a few environment variables you need to set first. The easiest way to do this is to add them to a `.env` file in the same directory as the `docker-compose.yml` file, but they can be set in any way you normally would set environment variables.

--- a/app/controllers/mit_download_controller.rb
+++ b/app/controllers/mit_download_controller.rb
@@ -1,0 +1,20 @@
+class MitDownloadController < ApplicationController
+  def file
+    key = [params[:id], params[:format]].join('.')
+
+    redirect_to presign_this(key)
+  end
+
+  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Presigner.html
+  def presign_this(layer_id_s)
+    # for minio
+    if Rails.env.test? || Rails.env.development?
+      Aws.config[:s3] = { endpoint: ENV['MINIO_URL'], force_path_style: true }
+    end
+
+    signer = Aws::S3::Presigner.new
+    signer.presigned_url(:get_object, bucket: ENV['AWS_S3_BUCKET'],
+                                      key: layer_id_s,
+                                      expires_in: 900)
+  end
+end

--- a/app/views/catalog/_downloads.html.erb
+++ b/app/views/catalog/_downloads.html.erb
@@ -1,13 +1,33 @@
 <% document ||= @document %>
 <% if document_downloadable? %>
+
   <div class='btn-group' itemprop='distribution' itemscope='itemscope' itemtype='http://schema.org/DataDownload'>
+
     <%= render 'downloads_primary' %>
-    <%= render 'downloads_secondary' %>
+    <%= render 'downloads_secondary' unless document['dct_provenance_s'] == "MIT" %>
   </div>
+
   <% elsif document.restricted? && document.same_institution? %>
+
     <div class='panel-body'>
-      <%= link_to(t('geoblacklight.tools.login_to_view'),
-                  user_shibboleth_omniauth_authorize_path,
-                  class: "btn btn-primary btn-wrap") %>
+      <% if ENV['AUTH_TYPE'] == 'developer' %>
+
+        <%= link_to(t('geoblacklight.tools.login_to_view'),
+                    user_developer_omniauth_authorize_path,
+                    class: "btn btn-primary btn-wrap") %>
+
+      <% elsif ENV['AUTH_TYPE'] == 'saml' %>
+
+        <%= link_to(t('geoblacklight.tools.login_to_view'),
+                    user_saml_omniauth_authorize_path,
+                    class: "btn btn-primary btn-wrap") %>
+
+      <% else %>
+
+        <%= link_to(t('geoblacklight.tools.login_to_view'),
+                    user_shibboleth_omniauth_authorize_path,
+                    class: "btn btn-primary btn-wrap") %>
+
+      <% end %>
     </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  
+
   concern :gbl_exportable, Geoblacklight::Routes::Exportable.new
 resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
   concerns :gbl_exportable
@@ -45,6 +45,8 @@ resources :download, only: [:show]
       delete 'clear'
     end
   end
+
+  get '/mit_download/:id', to: 'mit_download#file', as: 'mit_download'
 
   get '*unmatched_route', to: 'application#route_not_found'
 


### PR DESCRIPTION
This provides expiring URLs to download the original zipped layers for public layers or if the user is signed in.

Currently the URLs expire in 15 minutes, but that can be adjusted.

There are some assumptions made that may not be true about file naming conventions, etc.

I think this will work, but it's currently being presented more for discussion to ensure we are talking about the same things. 