### PR TITLE
Re-add therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'rsolr', '~> 1.0'
 gem 'sass-rails', '~> 5.0'
 gem 'sentry-raven'
 gem 'solr_wrapper', '>= 0.3'
+gem 'therubyracer', platforms: :ruby
 gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     leaflet-rails (0.7.7)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -261,6 +262,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.1)
@@ -306,6 +308,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -354,8 +359,9 @@ DEPENDENCIES
   sentry-raven
   solr_wrapper (>= 0.3)
   sqlite3 (~> 1.3.6)
+  therubyracer
   uglifier (>= 1.3.0)
   web-console
 
 BUNDLED WITH
-   1.16.2
+   1.17.2


### PR DESCRIPTION
This was removed when the new deployment was switched over to alpine
linux. Adding it back as it's still required for the old deployment.