### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,0 +1,12 @@
+name: Deploy staging
+on: workflow_dispatch
+jobs:
+  deploy:
+    name: Deploy staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: make dist
+      - name: Deploy
+        run: make stage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+name: Test
+on: push
+jobs:
+  test:
+    name: Build container
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: make dist

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dist publish promote
+.PHONY: help dist publish stage promote
 SHELL=/bin/bash
 ECR_REGISTRY=672626379771.dkr.ecr.us-east-1.amazonaws.com
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
@@ -16,6 +16,9 @@ publish: ## Push and tag the latest image (use `make dist && make publish`)
 	$$(aws ecr get-login --no-include-email --region us-east-1)
 	docker push $(ECR_REGISTRY)/geoblacklight-stage:latest
 	docker push $(ECR_REGISTRY)/geoblacklight-stage:`git describe --always`
+
+stage: publish ## Deploy image to staging and redeploy service
+	aws ecs update-service --cluster geoblacklight-stage --service geoblacklight-stage --force-new-deployment
 
 promote: ## Promote the current staging build to production
 	$$(aws ecr get-login --no-include-email --region us-east-1)


### PR DESCRIPTION
This adds two actions. The first will run on every push and just tests
that the container builds. The second, hopefully, will add a button to
the Actions page to manually redeploy staging.