### PR TITLE
Add accessibility link to footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,6 +24,7 @@
             <%= render partial: 'shared/help' %>
           </li>
           <li><a href="https://libguides.mit.edu/gis">GIS at MIT</a></li>
+          <li><a href="https://libraries.mit.edu/accessibility">Accessibility</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This is partial work on [UXWS-1017](https://mitlibraries.atlassian.net/browse/UXWS-1017), which is blocked by [ENGX-35](https://mitlibraries.atlassian.net/browse/ENGX-35). The remaining work on UXWS-1017 will conclude as soon as the upgrades land, but we want to make sure to include the a11y link in the meantime.

The changes are live in staging, or see screenshot below.

![Screen Shot 2020-10-16 at 11 02 00 AM](https://user-images.githubusercontent.com/16103405/96275096-537f4b00-0f9f-11eb-8da4-67d58a765d6e.png)

